### PR TITLE
Update devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,16 +1,9 @@
-// For format details, see https://aka.ms/devcontainer.json. For config options, see the
-// README at: https://github.com/devcontainers/templates/tree/main/src/debian
 {
-	"name": "SSO",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/base:bullseye",
-	// Features to add to the dev container. More info: https://containers.dev/features.
+	"name": "sso",
+	"image": "mcr.microsoft.com/devcontainers/base:debian12",
 	"features": {
 		"ghcr.io/bendwyer/devcontainer-features/terraform:1": {}
 	},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Configure tool-specific properties.
 	"customizations": {
 		"vscode": {
 			"extensions": [
@@ -22,9 +15,7 @@
 			],
       "settings": {
         "dev.containers.copyGitConfig": true
-      }			
+      }
 		}
 	}
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
 }


### PR DESCRIPTION
This PR updates the devcontainer config, removing extra spaces and unnecessary comments, while making the base image easier to understand (bookworm vs debian12).