### PR TITLE
Move cloudflare version constraint to root

### DIFF
--- a/terraform/modules/required-providers/versions.tf
+++ b/terraform/modules/required-providers/versions.tf
@@ -12,9 +12,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 4.52.0, < 5.0.0"
-      # lots of bugs, downgrading for now
-      # version = ">= 5.5.0"
+      version = ">= 4.52.0"
     }
     grafana = {
       source  = "grafana/grafana"

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -12,9 +12,8 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
-      # lots of bugs, downgrading for now
-      # version = "~>5.0"
+      version = "~> 4.0, < 5.0.0"
+      # lots of bugs in 5.0, pinning to 4.0 for now
     }
     grafana = {
       source  = "grafana/grafana"


### PR DESCRIPTION
This PR moves the version constraint for `cloudflare/cloudflare` from the child module to the root. This should fix dependabot not being able to correctly calulate updates for `cloudflare/cloudflare`.

Similar issue found here: https://github.com/dependabot/dependabot-core/issues/12071