### PR TITLE
Add HCP Terraform credentials mount to dev container config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -17,5 +17,12 @@
         "dev.containers.copyGitConfig": true
       }
 		}
-	}
+	},
+  "mounts": [
+    {
+      "source": "${localEnv:HOME}/.terraformrc",
+      "target": "/home/vscode/.terraformrc,readonly",
+      "type": "bind"
+    }
+  ]	
 }


### PR DESCRIPTION
This PR mounts the HCP Terraform credentials file into the dev container so `terraform login` can be skipped.