### PR TITLE
feat(hcp-terraform): manage SSO for multiple orgs

### DIFF
--- a/terraform/modules/hcp-terraform/main.tf
+++ b/terraform/modules/hcp-terraform/main.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zero_trust_access_application" "this" {
   account_id = var.cloudflare_account_id
-  name       = "HCP Terraform"
+  name       = var.cloudflare_access_app_name
   allowed_idps = [
     var.cloudflare_zero_trust_access_identity_provider
   ]

--- a/terraform/modules/hcp-terraform/variables.tf
+++ b/terraform/modules/hcp-terraform/variables.tf
@@ -1,3 +1,9 @@
+variable "cloudflare_access_app_name" {
+  default     = "HCP Terraform"
+  description = "Cloudflare Access application name."
+  type        = string
+}
+
 variable "cloudflare_account_id" {
   description = "Cloudflare account id."
   type        = string

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,16 +6,16 @@ output "hcp_public_key" {
   value = module.hcp.public_key
 }
 
-output "hcp_terraform_sso_endpoint" {
-  value = module.hcp_terraform.sso_endpoint
+output "hcp_terraform_sso_endpoints" {
+  value = { for k, v in module.hcp_terraform : k => v.sso_endpoint }
 }
 
-output "hcp_terraform_idp_entity_id" {
-  value = module.hcp_terraform.idp_entity_id
+output "hcp_terraform_idp_entity_ids" {
+  value = { for k, v in module.hcp_terraform : k => v.idp_entity_id }
 }
 
-output "hcp_terraform_public_key" {
-  value = module.hcp_terraform.public_key
+output "hcp_terraform_public_keys" {
+  value = { for k, v in module.hcp_terraform : k => v.public_key }
 }
 
 output "iam_identity_center_sso_endpoint" {

--- a/terraform/saas.tf
+++ b/terraform/saas.tf
@@ -26,13 +26,15 @@ module "hcp" {
 }
 
 module "hcp_terraform" {
-  source = "./modules/hcp-terraform"
+  for_each = var.hcp_terraform_orgs
+  source   = "./modules/hcp-terraform"
 
+  cloudflare_access_app_name                     = each.value.cloudflare_access_app_name
   cloudflare_account_id                          = var.cloudflare_account_id
   cloudflare_zero_trust_access_identity_provider = module.cloudflare_access.auth0_idp_oidc
   cloudflare_zero_trust_access_policy            = module.cloudflare_access.private_applications_policy
-  hcp_terraform_acs_url                          = var.hcp_terraform_acs_url
-  hcp_terraform_entity_id                        = var.hcp_terraform_entity_id
+  hcp_terraform_acs_url                          = each.value.acs_url
+  hcp_terraform_entity_id                        = each.value.entity_id
 }
 
 module "tailscale" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -89,14 +89,14 @@ variable "hcp_organization_id" {
   type        = string
 }
 
-variable "hcp_terraform_acs_url" {
-  description = "SAML Assertion Consumer Service (ACS) url."
-  type        = string
-}
-
-variable "hcp_terraform_entity_id" {
-  description = "SAML Entity ID. Can also be called Issuer URL or Audience."
-  type        = string
+variable "hcp_terraform_orgs" {
+  default     = {}
+  description = "HCP Terraform orgs to register as Cloudflare Access SaaS applications. Empty map registers none."
+  type = map(object({
+    acs_url                    = string
+    cloudflare_access_app_name = optional(string, "HCP Terraform")
+    entity_id                  = string
+  }))
 }
 
 variable "onepassword_vault_uuid" {


### PR DESCRIPTION
Allows configuring SSO for multiple HCP Terraform organizations, and prevents needing to add many more one-time vars for each added org.

Adds `hcp_terraform_orgs` with the following data structure:

```hcl
{
  org1 = {
    acs_url   = "https://app.terraform.io/sso/saml/samlconf-<id>/acs"
    cloudflare_access_app_name = "HCP Terraform - org1" // can also be left out to use variable default
    entity_id = "https://app.terraform.io/sso/saml/samlconf-<id>/metadata"
  }
  org2 = {
    acs_url   = "https://app.terraform.io/sso/saml/samlconf-<id>/acs"
    cloudflare_access_app_name = "HCP Terraform - org2"
    entity_id = "https://app.terraform.io/sso/saml/samlconf-<id>/metadata"
  }
}
```