### PR TITLE
fix(hcp-terraform): switch to scalar outputs

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,16 +6,28 @@ output "hcp_public_key" {
   value = module.hcp.public_key
 }
 
-output "hcp_terraform_sso_endpoints" {
-  value = { for k, v in module.hcp_terraform : k => v.sso_endpoint }
+output "hcp_terraform_static_sso_endpoint" {
+  value = try(module.hcp_terraform["static"].sso_endpoint, "")
 }
 
-output "hcp_terraform_idp_entity_ids" {
-  value = { for k, v in module.hcp_terraform : k => v.idp_entity_id }
+output "hcp_terraform_static_idp_entity_id" {
+  value = try(module.hcp_terraform["static"].idp_entity_id, "")
 }
 
-output "hcp_terraform_public_keys" {
-  value = { for k, v in module.hcp_terraform : k => v.public_key }
+output "hcp_terraform_static_public_key" {
+  value = try(module.hcp_terraform["static"].public_key, "")
+}
+
+output "hcp_terraform_ephemeral_sso_endpoint" {
+  value = try(module.hcp_terraform["ephemeral"].sso_endpoint, "")
+}
+
+output "hcp_terraform_ephemeral_idp_entity_id" {
+  value = try(module.hcp_terraform["ephemeral"].idp_entity_id, "")
+}
+
+output "hcp_terraform_ephemeral_public_key" {
+  value = try(module.hcp_terraform["ephemeral"].public_key, "")
 }
 
 output "iam_identity_center_sso_endpoint" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -91,7 +91,7 @@ variable "hcp_organization_id" {
 
 variable "hcp_terraform_orgs" {
   default     = {}
-  description = "HCP Terraform orgs to register as Cloudflare Access SaaS applications. Empty map registers none."
+  description = "HCP Terraform orgs to register as Cloudflare Access SaaS applications. Use keys 'static' and 'ephemeral' to match scalar outputs. Empty map registers none."
   type = map(object({
     acs_url                    = string
     cloudflare_access_app_name = optional(string, "HCP Terraform")


### PR DESCRIPTION
Adds outputs for static and ephemeral orgs as scalars to make copy/paste of outputs easier with the HCP Terraform UI.