### PR TITLE
Revert HCP Terraform multi-org changes

### DIFF
--- a/terraform/modules/hcp-terraform/main.tf
+++ b/terraform/modules/hcp-terraform/main.tf
@@ -1,6 +1,6 @@
 resource "cloudflare_zero_trust_access_application" "this" {
   account_id = var.cloudflare_account_id
-  name       = var.cloudflare_access_app_name
+  name       = "HCP Terraform"
   allowed_idps = [
     var.cloudflare_zero_trust_access_identity_provider
   ]

--- a/terraform/modules/hcp-terraform/variables.tf
+++ b/terraform/modules/hcp-terraform/variables.tf
@@ -1,9 +1,3 @@
-variable "cloudflare_access_app_name" {
-  default     = "HCP Terraform"
-  description = "Cloudflare Access application name."
-  type        = string
-}
-
 variable "cloudflare_account_id" {
   description = "Cloudflare account id."
   type        = string

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,16 +6,16 @@ output "hcp_public_key" {
   value = module.hcp.public_key
 }
 
-output "hcp_terraform_sso_endpoints" {
-  value = { for k, v in module.hcp_terraform : k => v.sso_endpoint }
+output "hcp_terraform_sso_endpoint" {
+  value = module.hcp_terraform.sso_endpoint
 }
 
-output "hcp_terraform_idp_entity_ids" {
-  value = { for k, v in module.hcp_terraform : k => v.idp_entity_id }
+output "hcp_terraform_idp_entity_id" {
+  value = module.hcp_terraform.idp_entity_id
 }
 
-output "hcp_terraform_public_keys" {
-  value = { for k, v in module.hcp_terraform : k => v.public_key }
+output "hcp_terraform_public_key" {
+  value = module.hcp_terraform.public_key
 }
 
 output "iam_identity_center_sso_endpoint" {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -6,28 +6,16 @@ output "hcp_public_key" {
   value = module.hcp.public_key
 }
 
-output "hcp_terraform_static_sso_endpoint" {
-  value = try(module.hcp_terraform["static"].sso_endpoint, "")
+output "hcp_terraform_sso_endpoints" {
+  value = { for k, v in module.hcp_terraform : k => v.sso_endpoint }
 }
 
-output "hcp_terraform_static_idp_entity_id" {
-  value = try(module.hcp_terraform["static"].idp_entity_id, "")
+output "hcp_terraform_idp_entity_ids" {
+  value = { for k, v in module.hcp_terraform : k => v.idp_entity_id }
 }
 
-output "hcp_terraform_static_public_key" {
-  value = try(module.hcp_terraform["static"].public_key, "")
-}
-
-output "hcp_terraform_ephemeral_sso_endpoint" {
-  value = try(module.hcp_terraform["ephemeral"].sso_endpoint, "")
-}
-
-output "hcp_terraform_ephemeral_idp_entity_id" {
-  value = try(module.hcp_terraform["ephemeral"].idp_entity_id, "")
-}
-
-output "hcp_terraform_ephemeral_public_key" {
-  value = try(module.hcp_terraform["ephemeral"].public_key, "")
+output "hcp_terraform_public_keys" {
+  value = { for k, v in module.hcp_terraform : k => v.public_key }
 }
 
 output "iam_identity_center_sso_endpoint" {

--- a/terraform/saas.tf
+++ b/terraform/saas.tf
@@ -26,15 +26,13 @@ module "hcp" {
 }
 
 module "hcp_terraform" {
-  for_each = var.hcp_terraform_orgs
-  source   = "./modules/hcp-terraform"
+  source = "./modules/hcp-terraform"
 
-  cloudflare_access_app_name                     = each.value.cloudflare_access_app_name
   cloudflare_account_id                          = var.cloudflare_account_id
   cloudflare_zero_trust_access_identity_provider = module.cloudflare_access.auth0_idp_oidc
   cloudflare_zero_trust_access_policy            = module.cloudflare_access.private_applications_policy
-  hcp_terraform_acs_url                          = each.value.acs_url
-  hcp_terraform_entity_id                        = each.value.entity_id
+  hcp_terraform_acs_url                          = var.hcp_terraform_acs_url
+  hcp_terraform_entity_id                        = var.hcp_terraform_entity_id
 }
 
 module "tailscale" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -89,14 +89,14 @@ variable "hcp_organization_id" {
   type        = string
 }
 
-variable "hcp_terraform_orgs" {
-  default     = {}
-  description = "HCP Terraform orgs to register as Cloudflare Access SaaS applications. Empty map registers none."
-  type = map(object({
-    acs_url                    = string
-    cloudflare_access_app_name = optional(string, "HCP Terraform")
-    entity_id                  = string
-  }))
+variable "hcp_terraform_acs_url" {
+  description = "SAML Assertion Consumer Service (ACS) url."
+  type        = string
+}
+
+variable "hcp_terraform_entity_id" {
+  description = "SAML Entity ID. Can also be called Issuer URL or Audience."
+  type        = string
 }
 
 variable "onepassword_vault_uuid" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -91,7 +91,7 @@ variable "hcp_organization_id" {
 
 variable "hcp_terraform_orgs" {
   default     = {}
-  description = "HCP Terraform orgs to register as Cloudflare Access SaaS applications. Use keys 'static' and 'ephemeral' to match scalar outputs. Empty map registers none."
+  description = "HCP Terraform orgs to register as Cloudflare Access SaaS applications. Empty map registers none."
   type = map(object({
     acs_url                    = string
     cloudflare_access_app_name = optional(string, "HCP Terraform")


### PR DESCRIPTION
- Reverts #101 (`feat(hcp-terraform): manage SSO for multiple orgs`) and #102 (`fix(hcp-terraform): switch to scalar outputs`), restoring the single-org HCP Terraform SSO setup as of #100.
- The `hcp_terraform_orgs` map variable and `static`/`ephemeral`-keyed outputs are gone; `hcp_terraform_acs_url` and `hcp_terraform_entity_id` are back as scalar inputs, and outputs return to
   `hcp_terraform_sso_endpoint` / `_idp_entity_id` / `_public_key`.