### PR TITLE
fix(hcp-terraform): add alias for aws provider

### DIFF
--- a/terraform/modules/aws-iam-identity-center/versions.tf
+++ b/terraform/modules/aws-iam-identity-center/versions.tf
@@ -2,8 +2,7 @@ terraform {
 
   required_providers {
     aws = {
-      source                = "hashicorp/aws"
-      configuration_aliases = [aws.MANAGEMENT]
+      source = "hashicorp/aws"
     }
     cloudflare = {
       source = "cloudflare/cloudflare"

--- a/terraform/modules/aws-iam-identity-center/versions.tf
+++ b/terraform/modules/aws-iam-identity-center/versions.tf
@@ -2,7 +2,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source                = "hashicorp/aws"
+      configuration_aliases = [aws.MANAGEMENT]
     }
     cloudflare = {
       source = "cloudflare/cloudflare"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -5,8 +5,9 @@ provider "auth0" {
 }
 
 provider "aws" {
-  alias  = "MANAGEMENT"
-  region = var.aws_region
+  alias               = "MANAGEMENT"
+  region              = var.aws_region
+  shared_config_files = [var.tfc_aws_dynamic_credentials.aliases["MANAGEMENT"].shared_config_file]
 }
 
 provider "cloudflare" {

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -5,6 +5,7 @@ provider "auth0" {
 }
 
 provider "aws" {
+  alias  = "MANAGEMENT"
   region = var.aws_region
 }
 

--- a/terraform/saas.tf
+++ b/terraform/saas.tf
@@ -1,5 +1,8 @@
 module "aws_iam_identity_center" {
   source = "./modules/aws-iam-identity-center"
+  providers = {
+    aws = aws.MANAGEMENT
+  }
 
   cloudflare_account_id                          = var.cloudflare_account_id
   cloudflare_zero_trust_access_identity_provider = module.cloudflare_access.auth0_idp_oidc

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -113,3 +113,15 @@ variable "onepassword_item_uuid_cloudflare" {
   description = "1Password item uuid for Cloudflare credential."
   type        = string
 }
+
+variable "tfc_aws_dynamic_credentials" {
+  description = "Object containing AWS dynamic credentials configuration"
+  type = object({
+    default = object({
+      shared_config_file = string
+    })
+    aliases = map(object({
+      shared_config_file = string
+    }))
+  })
+}


### PR DESCRIPTION
Due to some reorganization of aws accounts behind the scenes, an alias is necessary now to be able to connect to the correct account.