### PR TITLE
feat(outputs): expose cloudflare access idp + private-applications policy IDs

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,11 @@
+output "cloudflare_access_auth0_idp_oidc_id" {
+  value = module.cloudflare_access.auth0_idp_oidc
+}
+
+output "cloudflare_access_private_applications_policy_id" {
+  value = module.cloudflare_access.private_applications_policy
+}
+
 output "hcp_sso_endpoint" {
   value = module.hcp.sso_endpoint
 }


### PR DESCRIPTION
The `sso` workspace's internal `cloudflare_access` module already exposes `auth0_idp_oidc` and `private_applications_policy` as module outputs, but those weren't re-exported at the workspace level, preventing consumption via `tfe_outputs`.

This PR adds two top-level output blocks so these outputs can be consumed by other HCP Terraform workspaces.