### PR TITLE
chore(terraform): migrate Cloudflare provider v4 to v5

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The following API token permissions are required for terraform:
 
 If you're struggling to find reference ID's for Cloudflare objects to import, sometimes the information can be found by inspecting the page using the "Network" tab in your browser's development tools. Filter by "XHR/Fetch" (Safari) and you should find a corresponding item that contains the relevant ID. You may need to navigate to different pages for the correct info to show up though.
 
-The v4.x provider is preferred for the moment since 5.x has a lot of problems.
+The provider is on v5.x, migrated from v4.x with [`tf-migrate`](https://github.com/cloudflare/tf-migrate) plus manual fixups. Provider versions are constrained to `~> 5.0` (`>= 5.19.1`, the floor for v5's automatic state upgraders).
 
 #### Links
 

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -40,25 +40,19 @@ provider "registry.terraform.io/auth0/auth0" {
 }
 
 provider "registry.terraform.io/cloudflare/cloudflare" {
-  version     = "4.52.7"
-  constraints = "~> 4.0, >= 4.52.0"
+  version     = "5.19.1"
+  constraints = "~> 5.0, >= 5.19.1"
   hashes = [
-    "h1:pPItIWii5oymR+geZB219ROSPuSODPLTlM4S/u8xLvM=",
-    "zh:0c904ce31a4c6c4a5b3bf7ff1560e77c0cc7e2450c8553ded8e8c90398e1418b",
-    "zh:36183d310c36373fe4cb936b83c595c6fd3b0a94bc7827f28e5789ccbf59752e",
-    "zh:556a568a6f0235e8f41647de9e4d3a1e7b1d6502df8b19b54ec441f1c653ea10",
-    "zh:633ebbd5b0245e75e500ef9be4d9e62288f97e8da3baaa51323892a786d90285",
-    "zh:6acfe60cf52a65ba8f044f748548d2119e7f4fd7f8ebcb14698960d87c68f529",
-    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
-    "zh:904acc31ebb9d6ef68c792074b30532ee61bf515f19e0a3c75b46f126cca1f13",
-    "zh:a1d0a81246afc8750286d3f6fe7a8fbe6460dd2662407b28dbfbabb612e5fa9d",
-    "zh:a41a36fe253fc365fe2b7ffc749624688b2693b4634862fda161179ab100029f",
-    "zh:a7ef269e77ffa8715c8945a2c14322c7ff159ea44c15f62505f3cbb2cae3b32d",
-    "zh:b01aa3bed30610633b762df64332b26f8844a68c3960cebcb30f04918efc67fe",
-    "zh:b069cc2cd18cae10757df3ae030508eac8d55de7e49eda7a5e3e11f2f7fe6455",
-    "zh:b2d2c6313729ebb7465dceece374049e2d08bda34473901be9ff46a8836d42b2",
-    "zh:db0e114edaf4bc2f3d4769958807c83022bfbc619a00bdf4c4bd17faa4ab2d8b",
-    "zh:ecc0aa8b9044f664fd2aaf8fa992d976578f78478980555b4b8f6148e8d1a5fe",
+    "h1:mopYISyLkUVUwMjJbuPenxIUVDrna1/7ACB1hfMfciU=",
+    "zh:0651618000db705564dab5a25322b9d76ea54b7dd78931ed3565497b559babeb",
+    "zh:1a7847e9479fb6d21a65ef933ffae1416b1e4b44ca940c0d6c50fc4248cc4a0d",
+    "zh:5597cee5854131045eb9f201ae3a70b59c51955d31a647d9616863c746d902cb",
+    "zh:580786830d93e35b957754fd4c62d4681a3b19abc28b757e41acba26455663b1",
+    "zh:83c4bdfb0e74fd50e56fff3c461d76c1c1ec61af3f679e4de1aa70b5ed05a09f",
+    "zh:abb4d1052cee61d80f9cb51e5421e3c118312403afb7104b98bd7e310ac736ee",
+    "zh:b0aeeb3d66ea4d719989875e778c477065ba941e3a76e9a8caacc3be08208dd9",
+    "zh:e43b4b2dfcec1ce2115f5a5c86042d432deb49bee8eae103eb56d97ea02e2e3b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
   ]
 }
 

--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -6,7 +6,7 @@ import {
 
 # Import Cloudflare Access organization
 import {
-  to = module.cloudflare_access.cloudflare_zero_trust_access_organization.this
+  to = module.cloudflare_access.cloudflare_zero_trust_organization.this
   id = var.cloudflare_account_id
 }
 

--- a/terraform/modules/aws-iam-identity-center/main.tf
+++ b/terraform/modules/aws-iam-identity-center/main.tf
@@ -4,18 +4,19 @@ resource "cloudflare_zero_trust_access_application" "this" {
   allowed_idps = [
     var.cloudflare_zero_trust_access_identity_provider
   ]
-  auto_redirect_to_identity    = true
-  session_duration             = "6h"
-  skip_app_launcher_login_page = false
-  type                         = "saas"
-  logo_url                     = "https://a0.awsstatic.com/libra-css/images/site/fav/favicon.ico"
+  auto_redirect_to_identity = true
+  session_duration          = "6h"
+  type                      = "saas"
+  logo_url                  = "https://a0.awsstatic.com/libra-css/images/site/fav/favicon.ico"
 
   policies = [
-    var.cloudflare_zero_trust_access_policy
+    {
+      id         = var.cloudflare_zero_trust_access_policy
+      precedence = 1
+    }
   ]
 
-  saas_app {
-    # auth_type = "saml"
+  saas_app = {
     consumer_service_url = var.aws_iam_identity_center_acs_url
     name_id_format       = "email"
     sp_entity_id         = var.aws_iam_identity_center_entity_id

--- a/terraform/modules/aws-iam-identity-center/outputs.tf
+++ b/terraform/modules/aws-iam-identity-center/outputs.tf
@@ -1,11 +1,11 @@
 output "sso_endpoint" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].sso_endpoint
+  value = cloudflare_zero_trust_access_application.this.saas_app.sso_endpoint
 }
 
 output "idp_entity_id" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].idp_entity_id
+  value = cloudflare_zero_trust_access_application.this.saas_app.idp_entity_id
 }
 
 output "public_key" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].public_key
+  value = cloudflare_zero_trust_access_application.this.saas_app.public_key
 }

--- a/terraform/modules/cloudflare-access/main.tf
+++ b/terraform/modules/cloudflare-access/main.tf
@@ -30,7 +30,7 @@ resource "cloudflare_zero_trust_access_identity_provider" "this" {
   name       = "Auth0"
   type       = "oidc"
 
-  config {
+  config = {
     client_id        = data.auth0_client.this.client_id
     client_secret    = data.auth0_client.this.client_secret
     auth_url         = "https://${data.auth0_tenant.this.domain}/authorize"
@@ -46,7 +46,6 @@ resource "cloudflare_zero_trust_access_identity_provider" "this" {
     claims = [
       "email_verified"
     ]
-    support_groups = false
   }
 }
 
@@ -55,9 +54,9 @@ resource "cloudflare_zero_trust_access_policy" "app_launcher" {
   name       = "app-launcher"
   decision   = "allow"
 
-  include {
-    email_domain = var.cloudflare_access_policy_allow_domains
-  }
+  include = [for domain in var.cloudflare_access_policy_allow_domains : {
+    email_domain = { domain = domain }
+  }]
 
   lifecycle {
     create_before_destroy = true
@@ -69,9 +68,9 @@ resource "cloudflare_zero_trust_access_policy" "private_applications" {
   name       = "private-applications"
   decision   = "allow"
 
-  include {
-    email_domain = var.cloudflare_access_policy_allow_domains
-  }
+  include = [for domain in var.cloudflare_access_policy_allow_domains : {
+    email_domain = { domain = domain }
+  }]
 
   lifecycle {
     create_before_destroy = true
@@ -83,33 +82,33 @@ resource "cloudflare_zero_trust_access_policy" "shared_applications" {
   name       = "shared-applications"
   decision   = "allow"
 
-  include {
-    email_domain = var.cloudflare_access_policy_allow_domains
-  }
+  include = [for domain in var.cloudflare_access_policy_allow_domains : {
+    email_domain = { domain = domain }
+  }]
 
   lifecycle {
     create_before_destroy = true
   }
 }
 
-resource "cloudflare_zero_trust_access_organization" "this" {
+resource "cloudflare_zero_trust_organization" "this" {
   account_id  = var.cloudflare_account_id
   name        = "${var.cloudflare_access_team_domain}.cloudflareaccess.com"
   auth_domain = "${var.cloudflare_access_team_domain}.cloudflareaccess.com"
-
-  custom_pages {}
-
-  login_design {}
 
   lifecycle {
     prevent_destroy = true
   }
 }
 
+moved {
+  from = cloudflare_zero_trust_access_organization.this
+  to   = cloudflare_zero_trust_organization.this
+}
+
 # App Launcher
 resource "cloudflare_zero_trust_access_application" "this" {
-  account_id           = var.cloudflare_account_id
-  app_launcher_visible = false
+  account_id = var.cloudflare_account_id
   allowed_idps = [
     cloudflare_zero_trust_access_identity_provider.this.id
   ]
@@ -118,7 +117,10 @@ resource "cloudflare_zero_trust_access_application" "this" {
   skip_app_launcher_login_page = false
   type                         = "app_launcher"
   policies = [
-    cloudflare_zero_trust_access_policy.app_launcher.id
+    {
+      id         = cloudflare_zero_trust_access_policy.app_launcher.id
+      precedence = 1
+    }
   ]
 
   lifecycle {

--- a/terraform/modules/hcp-terraform/main.tf
+++ b/terraform/modules/hcp-terraform/main.tf
@@ -4,18 +4,19 @@ resource "cloudflare_zero_trust_access_application" "this" {
   allowed_idps = [
     var.cloudflare_zero_trust_access_identity_provider
   ]
-  auto_redirect_to_identity    = true
-  session_duration             = "6h"
-  skip_app_launcher_login_page = false
-  type                         = "saas"
-  logo_url                     = "https://app.terraform.io/favicon.ico"
+  auto_redirect_to_identity = true
+  session_duration          = "6h"
+  type                      = "saas"
+  logo_url                  = "https://app.terraform.io/favicon.ico"
 
   policies = [
-    var.cloudflare_zero_trust_access_policy
+    {
+      id         = var.cloudflare_zero_trust_access_policy
+      precedence = 1
+    }
   ]
 
-  saas_app {
-    # auth_type = "saml"
+  saas_app = {
     consumer_service_url = var.hcp_terraform_acs_url
     name_id_format       = "email"
     sp_entity_id         = var.hcp_terraform_entity_id

--- a/terraform/modules/hcp-terraform/outputs.tf
+++ b/terraform/modules/hcp-terraform/outputs.tf
@@ -1,11 +1,11 @@
 output "sso_endpoint" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].sso_endpoint
+  value = cloudflare_zero_trust_access_application.this.saas_app.sso_endpoint
 }
 
 output "idp_entity_id" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].idp_entity_id
+  value = cloudflare_zero_trust_access_application.this.saas_app.idp_entity_id
 }
 
 output "public_key" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].public_key
+  value = cloudflare_zero_trust_access_application.this.saas_app.public_key
 }

--- a/terraform/modules/hcp/main.tf
+++ b/terraform/modules/hcp/main.tf
@@ -5,17 +5,18 @@ resource "cloudflare_zero_trust_access_application" "this" {
   allowed_idps = [
     var.cloudflare_zero_trust_access_identity_provider
   ]
-  app_launcher_visible         = false
-  auto_redirect_to_identity    = true
-  session_duration             = "6h"
-  skip_app_launcher_login_page = false
-  type                         = "saas"
+  app_launcher_visible      = false
+  auto_redirect_to_identity = true
+  session_duration          = "6h"
+  type                      = "saas"
   policies = [
-    var.cloudflare_zero_trust_access_policy
+    {
+      id         = var.cloudflare_zero_trust_access_policy
+      precedence = 1
+    }
   ]
 
-  saas_app {
-    # auth_type = "saml"
+  saas_app = {
     consumer_service_url = var.hcp_acs_url
     name_id_format       = "email"
     sp_entity_id         = var.hcp_entity_id
@@ -34,15 +35,20 @@ resource "cloudflare_zero_trust_access_application" "bookmark" {
 
 
 data "cloudflare_zones" "this" {
-  filter {
-    name = var.cloudflare_zone_name
-  }
+  name = var.cloudflare_zone_name
 }
 
-resource "cloudflare_record" "this" {
-  zone_id = data.cloudflare_zones.this.zones[0]["id"]
-  name    = data.cloudflare_zones.this.zones[0]["name"]
+
+resource "cloudflare_dns_record" "this" {
+  zone_id = data.cloudflare_zones.this.result[0]["id"]
+  name    = data.cloudflare_zones.this.result[0]["name"]
   content = var.hcp_domain_verification_content
   comment = "HCP"
   type    = "TXT"
+  ttl     = 1
+}
+
+moved {
+  from = cloudflare_record.this
+  to   = cloudflare_dns_record.this
 }

--- a/terraform/modules/hcp/outputs.tf
+++ b/terraform/modules/hcp/outputs.tf
@@ -1,7 +1,7 @@
 output "sso_endpoint" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].sso_endpoint
+  value = cloudflare_zero_trust_access_application.this.saas_app.sso_endpoint
 }
 
 output "public_key" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].public_key
+  value = cloudflare_zero_trust_access_application.this.saas_app.public_key
 }

--- a/terraform/modules/required-providers/versions.tf
+++ b/terraform/modules/required-providers/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = ">= 4.52.0"
+      version = ">= 5.19.1"
     }
   }
 }

--- a/terraform/modules/tailscale/main.tf
+++ b/terraform/modules/tailscale/main.tf
@@ -4,27 +4,26 @@ resource "cloudflare_zero_trust_access_application" "this" {
   allowed_idps = [
     var.cloudflare_zero_trust_access_identity_provider
   ]
-  auto_redirect_to_identity    = true
-  session_duration             = "6h"
-  skip_app_launcher_login_page = false
-  type                         = "saas"
-  logo_url                     = var.cloudflare_zero_trust_access_application_logo_url
+  auto_redirect_to_identity = true
+  session_duration          = "6h"
+  type                      = "saas"
+  logo_url                  = var.cloudflare_zero_trust_access_application_logo_url
 
   policies = [
-    var.cloudflare_zero_trust_access_policy
+    {
+      id         = var.cloudflare_zero_trust_access_policy
+      precedence = 1
+    }
   ]
 
-  saas_app {
+  saas_app = {
     app_launcher_url = "https://login.tailscale.com"
     auth_type        = "oidc"
+    grant_types      = ["authorization_code"]
     redirect_uris = [
       "https://login.tailscale.com/a/oauth_response"
     ]
-    scopes = [
-      "openid",
-      "profile",
-      "email"
-    ]
+    scopes                = ["openid", "profile", "email"]
     access_token_lifetime = "5m"
   }
 }

--- a/terraform/modules/tailscale/outputs.tf
+++ b/terraform/modules/tailscale/outputs.tf
@@ -1,7 +1,7 @@
 output "client_id" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].client_id
+  value = cloudflare_zero_trust_access_application.this.saas_app.client_id
 }
 
 output "client_secret" {
-  value = cloudflare_zero_trust_access_application.this.saas_app[0].client_secret
+  value = cloudflare_zero_trust_access_application.this.saas_app.client_secret
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -12,8 +12,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
-      # lots of bugs in 5.0, pinning to 4.0 for now
+      version = "~> 5.0"
     }
     onepassword = {
       source  = "1Password/onepassword"


### PR DESCRIPTION
Migrate cloudflare/cloudflare v4.52.7 to v5.19.1 via [cloudflare/tf-migrate](https://github.com/cloudflare/tf-migrate) plus manual fixups it didn't cover:

- access policy `include` rewritten as a for-expression over the email-domain list (v5 `email_domain.domain` is scalar, not a list)
- drop `support_groups` (Azure-AD-only in v5) from the Auth0 OIDC IdP
- drop `app_launcher_visible` (App Launcher app) and `skip_app_launcher_login_page` (SaaS apps), invalid on those types in v5
- `saas_app[0].x` becomes `saas_app.x` in module outputs (object, not list)
- pin Tailscale `saas_app.grant_types = ["authorization_code"]` to preserve the OIDC flow (a server-side default in v4 state, not v4 config)
- `moved` blocks for the two renames: `access_organization` to `organization`, `record` to `dns_record`
- keep provider versions centralized (root `~> 5.0`, required-providers `>= 5.19.1`); strip the per-module pins tf-migrate injected

Given the sensitivity and blast radius of the migration, the changes tf-migrate made were double-checked with Claude against the v5 provider schema, then verified with terraform validate and a speculative plan.

## Plan

Speculative plan is clean: 0 to add, 5 to change, 0 to destroy. All five are benign one-time settling (computed fields, empty-block `{}` to null, server default session_duration). Both `prevent_destroy` resources update in-place; both renames tracked via `moved`.
