### PR TITLE
refactor: source the Cloudflare credential from an env var

### DIFF
--- a/terraform/credentials.tf
+++ b/terraform/credentials.tf
@@ -6,8 +6,3 @@ data "onepassword_item" "auth0" {
   vault = data.onepassword_vault.this.uuid
   uuid  = var.onepassword_item_uuid_auth0
 }
-
-data "onepassword_item" "cloudflare" {
-  vault = data.onepassword_vault.this.uuid
-  uuid  = var.onepassword_item_uuid_cloudflare
-}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -10,8 +10,6 @@ provider "aws" {
   shared_config_files = [var.tfc_aws_dynamic_credentials.aliases["MANAGEMENT"].shared_config_file]
 }
 
-provider "cloudflare" {
-  api_token = data.onepassword_item.cloudflare.credential
-}
+provider "cloudflare" {}
 
 provider "onepassword" {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -109,11 +109,6 @@ variable "onepassword_item_uuid_auth0" {
   type        = string
 }
 
-variable "onepassword_item_uuid_cloudflare" {
-  description = "1Password item uuid for Cloudflare credential."
-  type        = string
-}
-
 variable "tfc_aws_dynamic_credentials" {
   description = "Object containing AWS dynamic credentials configuration"
   type = object({


### PR DESCRIPTION
Switch the cloudflare provider to the `CLOUDFLARE_API_TOKEN` env var instead of reading the 1Password item in-code. Drops the in-code `data.onepassword_item.cloudflare` and the `onepassword_item_uuid_cloudflare` variable.