### PR TITLE
feat: provision Cloudflare dashboard SSO connector in a disabled state

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ The settings in AWS IAM Identity Center need to be manually configured. The [has
 
 - [SaaS Apps - AWS SSO](https://developers.cloudflare.com/cloudflare-one/applications/configure-apps/saas-apps/aws-sso-saas/)
 
+### Cloudflare Dashboard
+
+Cloudflare's own dashboard supports SSO via a [dashboard SSO connector](https://developers.cloudflare.com/fundamentals/manage-members/dashboard-sso/), managed by the [cloudflare-dashboard-sso](./terraform/modules/cloudflare-dashboard-sso) module. Creating the connector auto-generates the Zero Trust SSO application and its `allow email domain` policy, wired to the Auth0 IdP, so there is no SaaS application to configure manually.
+
+Domain ownership is verified with a `TXT` record (the `cloudflare_dashboard_sso=...` string) that Terraform creates from the connector's verification code. Cloudflare polls it for up to two days.
+
+Set `dashboard_sso_email_domain` to the email domain to enforce. Leave `dashboard_sso_enabled = false` until the connector reports `verified` (check the `module.cloudflare` outputs or the Members page), then set it to `true` in a separate change.
+
+> [!CAUTION]
+> Enabling the connector enforces SSO for every user with that email domain across all accounts, including users registered before SSO was configured. A broken IdP can lock you out.
+
+> [!IMPORTANT]
+> Before enabling, create a backup [account API token](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/) with the `SSO Connector Edit` role and store it securely. It is the only way to disable SSO from the API if an IdP change locks you out.
+
+#### Links
+
+- [Set up dashboard SSO](https://developers.cloudflare.com/fundamentals/manage-members/dashboard-sso/)
+
 ### HCP (HashiCorp Cloud Platform)
 
 The settings in HCP need to be manually configured. The [hashicorp/hcp](https://registry.terraform.io/providers/hashicorp/hcp/latest/docs) provider does not (yet) support this operation. Once SSO is enabled, users can no longer be invited to the organization and should instead be provisioned in the IdP (Auth0).

--- a/terraform/bookmarks.tf
+++ b/terraform/bookmarks.tf
@@ -16,13 +16,18 @@ module "auth0_dashboard" {
   cloudflare_account_id = var.cloudflare_account_id
 }
 
-module "cloudflare" {
+module "cloudflare_dashboard" {
   source = "./modules/cloudflare-access-bookmark"
 
   bookmark_name         = "Cloudflare"
   bookmark_logo_url     = "https://www.cloudflare.com/favicon.ico"
   bookmark_url          = "https://dash.cloudflare.com/login"
   cloudflare_account_id = var.cloudflare_account_id
+}
+
+moved {
+  from = module.cloudflare.cloudflare_zero_trust_access_application.this
+  to   = module.cloudflare_dashboard.cloudflare_zero_trust_access_application.this
 }
 
 module "github" {

--- a/terraform/modules/cloudflare-dashboard-sso/main.tf
+++ b/terraform/modules/cloudflare-dashboard-sso/main.tf
@@ -1,0 +1,21 @@
+resource "cloudflare_sso_connector" "this" {
+  account_id         = var.cloudflare_account_id
+  email_domain       = var.dashboard_sso_email_domain
+  begin_verification = true
+  enabled            = var.dashboard_sso_enabled
+}
+
+data "cloudflare_zones" "this" {
+  name = var.cloudflare_zone_name
+}
+
+# Domain ownership verification for the SSO connector. Cloudflare polls this
+# TXT record (the entire cloudflare_dashboard_sso=... string) until verified.
+resource "cloudflare_dns_record" "verification" {
+  zone_id = data.cloudflare_zones.this.result[0]["id"]
+  name    = var.dashboard_sso_email_domain
+  type    = "TXT"
+  content = cloudflare_sso_connector.this.verification.code
+  ttl     = 1
+  comment = "Cloudflare dashboard SSO domain verification"
+}

--- a/terraform/modules/cloudflare-dashboard-sso/outputs.tf
+++ b/terraform/modules/cloudflare-dashboard-sso/outputs.tf
@@ -1,0 +1,11 @@
+output "connector_id" {
+  value = cloudflare_sso_connector.this.id
+}
+
+output "verification_status" {
+  value = cloudflare_sso_connector.this.verification.status
+}
+
+output "verification_code" {
+  value = cloudflare_sso_connector.this.verification.code
+}

--- a/terraform/modules/cloudflare-dashboard-sso/variables.tf
+++ b/terraform/modules/cloudflare-dashboard-sso/variables.tf
@@ -1,0 +1,20 @@
+variable "cloudflare_account_id" {
+  description = "Cloudflare account id."
+  type        = string
+}
+
+variable "cloudflare_zone_name" {
+  description = "Cloudflare zone hosting the DNS for the SSO email domain."
+  type        = string
+}
+
+variable "dashboard_sso_email_domain" {
+  description = "Email domain to enforce Cloudflare dashboard SSO for."
+  type        = string
+}
+
+variable "dashboard_sso_enabled" {
+  description = "Whether to enforce dashboard SSO. Enable only after domain verification has succeeded."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/cloudflare-dashboard-sso/versions.tf
+++ b/terraform/modules/cloudflare-dashboard-sso/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+
+  required_providers {
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}

--- a/terraform/saas.tf
+++ b/terraform/saas.tf
@@ -45,3 +45,12 @@ module "tailscale" {
   cloudflare_zero_trust_access_identity_provider = module.cloudflare_access.auth0_idp_oidc
   cloudflare_zero_trust_access_policy            = module.cloudflare_access.private_applications_policy
 }
+
+module "cloudflare" {
+  source = "./modules/cloudflare-dashboard-sso"
+
+  cloudflare_account_id      = var.cloudflare_account_id
+  cloudflare_zone_name       = var.cloudflare_zone_name
+  dashboard_sso_email_domain = var.dashboard_sso_email_domain
+  dashboard_sso_enabled      = var.dashboard_sso_enabled
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -69,6 +69,17 @@ variable "cloudflare_zone_name" {
   type        = string
 }
 
+variable "dashboard_sso_email_domain" {
+  description = "Email domain to enforce Cloudflare dashboard SSO for."
+  type        = string
+}
+
+variable "dashboard_sso_enabled" {
+  description = "Whether to enforce Cloudflare dashboard SSO. Enable only after domain verification has succeeded."
+  type        = bool
+  default     = false
+}
+
 variable "hcp_acs_url" {
   description = "SAML Assertion Consumer Service (ACS) url."
   type        = string


### PR DESCRIPTION
Adds the `cloudflare-dashboard-sso` module (wired as `module "cloudflare"`): a `cloudflare_sso_connector` (Access as SP to the Auth0 OIDC IdP, `begin_verification = true`) plus a TXT record wired to `verification.code` for domain ownership. `dashboard_sso_enabled` defaults to `false`, so no no enforcement yet.

The Cloudflare dashboard bookmark stays (it's the dashboard's App Launcher tile); its module is renamed `cloudflare` -> `cloudflare_dashboard` (matching `auth0_dashboard`) to free `cloudflare` for the SSO module, with a `moved` block so it's a state move, not destroy/recreate.