### PR TITLE
chore: remove unused moved block

### DIFF
--- a/terraform/bookmarks.tf
+++ b/terraform/bookmarks.tf
@@ -25,11 +25,6 @@ module "cloudflare_dashboard" {
   cloudflare_account_id = var.cloudflare_account_id
 }
 
-moved {
-  from = module.cloudflare.cloudflare_zero_trust_access_application.this
-  to   = module.cloudflare_dashboard.cloudflare_zero_trust_access_application.this
-}
-
 module "github" {
   source = "./modules/cloudflare-access-bookmark"
 


### PR DESCRIPTION
Drops the `cloudflare -> cloudflare_dashboard` bookmark-rename `moved` block, which applied in a prior PR and is now a no-op.