### PR TITLE
feat(cloudflare): import and tweak Cloudflare dashboard SSO app

### DIFF
--- a/terraform/bookmarks.tf
+++ b/terraform/bookmarks.tf
@@ -16,15 +16,6 @@ module "auth0_dashboard" {
   cloudflare_account_id = var.cloudflare_account_id
 }
 
-module "cloudflare_dashboard" {
-  source = "./modules/cloudflare-access-bookmark"
-
-  bookmark_name         = "Cloudflare"
-  bookmark_logo_url     = "https://www.cloudflare.com/favicon.ico"
-  bookmark_url          = "https://dash.cloudflare.com/login"
-  cloudflare_account_id = var.cloudflare_account_id
-}
-
 module "github" {
   source = "./modules/cloudflare-access-bookmark"
 

--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -15,3 +15,9 @@ import {
   to = module.cloudflare_access.cloudflare_zero_trust_access_application.this
   id = "${var.cloudflare_account_id}/${var.cloudflare_access_app_launcher_id}"
 }
+
+# Import Cloudflare dashboard SSO app
+import {
+  to = module.cloudflare.cloudflare_zero_trust_access_application.dashboard_sso
+  id = "accounts/${var.cloudflare_account_id}/${var.dashboard_sso_app_id}"
+}

--- a/terraform/imports.tf
+++ b/terraform/imports.tf
@@ -18,6 +18,6 @@ import {
 
 # Import Cloudflare dashboard SSO app
 import {
-  to = module.cloudflare.cloudflare_zero_trust_access_application.dashboard_sso
+  to = module.cloudflare.cloudflare_zero_trust_access_application.this
   id = "accounts/${var.cloudflare_account_id}/${var.dashboard_sso_app_id}"
 }

--- a/terraform/modules/cloudflare-dashboard-sso/main.tf
+++ b/terraform/modules/cloudflare-dashboard-sso/main.tf
@@ -10,7 +10,7 @@ data "cloudflare_zones" "this" {
 }
 
 # Domain verification TXT record polled by Cloudflare until verified.
-resource "cloudflare_dns_record" "verification" {
+resource "cloudflare_dns_record" "this" {
   zone_id = data.cloudflare_zones.this.result[0]["id"]
   name    = var.dashboard_sso_email_domain
   type    = "TXT"
@@ -19,16 +19,23 @@ resource "cloudflare_dns_record" "verification" {
   comment = "Cloudflare dashboard SSO domain verification"
 }
 
+moved {
+  from = cloudflare_dns_record.verification
+  to   = cloudflare_dns_record.this
+}
+
 # Imported dash_sso app. Its launcher tile = IdP-initiated dashboard login.
 # Pins the allow-email-domain policy -- dropping it locks admins out.
-resource "cloudflare_zero_trust_access_application" "dashboard_sso" {
+resource "cloudflare_zero_trust_access_application" "this" {
   account_id                = var.cloudflare_account_id
   name                      = "Cloudflare"
   type                      = "dash_sso"
   logo_url                  = "https://www.cloudflare.com/favicon.ico"
   auto_redirect_to_identity = false
   session_duration          = "24h"
-  allowed_idps              = []
+  allowed_idps = [
+    var.cloudflare_zero_trust_access_identity_provider
+  ]
 
   policies = [
     {

--- a/terraform/modules/cloudflare-dashboard-sso/main.tf
+++ b/terraform/modules/cloudflare-dashboard-sso/main.tf
@@ -9,8 +9,7 @@ data "cloudflare_zones" "this" {
   name = var.cloudflare_zone_name
 }
 
-# Domain ownership verification for the SSO connector. Cloudflare polls this
-# TXT record (the entire cloudflare_dashboard_sso=... string) until verified.
+# Domain verification TXT record polled by Cloudflare until verified.
 resource "cloudflare_dns_record" "verification" {
   zone_id = data.cloudflare_zones.this.result[0]["id"]
   name    = var.dashboard_sso_email_domain
@@ -18,4 +17,35 @@ resource "cloudflare_dns_record" "verification" {
   content = cloudflare_sso_connector.this.verification.code
   ttl     = 1
   comment = "Cloudflare dashboard SSO domain verification"
+}
+
+# Imported dash_sso app. Its launcher tile = IdP-initiated dashboard login.
+# Pins the allow-email-domain policy -- dropping it locks admins out.
+resource "cloudflare_zero_trust_access_application" "dashboard_sso" {
+  account_id                = var.cloudflare_account_id
+  name                      = "Cloudflare"
+  type                      = "dash_sso"
+  logo_url                  = "https://www.cloudflare.com/favicon.ico"
+  auto_redirect_to_identity = false
+  session_duration          = "24h"
+  allowed_idps              = []
+
+  policies = [
+    {
+      id         = var.dashboard_sso_policy_id
+      precedence = 1
+    }
+  ]
+
+  saas_app = {
+    consumer_service_url = "https://dash.cloudflare.com/api/v4/saml/acs"
+    sp_entity_id         = "dash.cloudflare.com"
+    name_id_format       = "id"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+    # Not settable on dash_sso (defaults true); without this, apply nulls it.
+    ignore_changes = [app_launcher_visible]
+  }
 }

--- a/terraform/modules/cloudflare-dashboard-sso/variables.tf
+++ b/terraform/modules/cloudflare-dashboard-sso/variables.tf
@@ -3,6 +3,11 @@ variable "cloudflare_account_id" {
   type        = string
 }
 
+variable "cloudflare_zero_trust_access_identity_provider" {
+  description = "Name of IdP for Cloudflare Zero Trust Access."
+  type        = string
+}
+
 variable "cloudflare_zone_name" {
   description = "Cloudflare zone hosting the DNS for the SSO email domain."
   type        = string

--- a/terraform/modules/cloudflare-dashboard-sso/variables.tf
+++ b/terraform/modules/cloudflare-dashboard-sso/variables.tf
@@ -18,3 +18,8 @@ variable "dashboard_sso_enabled" {
   type        = bool
   default     = false
 }
+
+variable "dashboard_sso_policy_id" {
+  description = "ID of the connector-generated allow-email-domain policy attached to the dash_sso app."
+  type        = string
+}

--- a/terraform/saas.tf
+++ b/terraform/saas.tf
@@ -53,4 +53,5 @@ module "cloudflare" {
   cloudflare_zone_name       = var.cloudflare_zone_name
   dashboard_sso_email_domain = var.dashboard_sso_email_domain
   dashboard_sso_enabled      = var.dashboard_sso_enabled
+  dashboard_sso_policy_id    = var.dashboard_sso_policy_id
 }

--- a/terraform/saas.tf
+++ b/terraform/saas.tf
@@ -49,9 +49,10 @@ module "tailscale" {
 module "cloudflare" {
   source = "./modules/cloudflare-dashboard-sso"
 
-  cloudflare_account_id      = var.cloudflare_account_id
-  cloudflare_zone_name       = var.cloudflare_zone_name
-  dashboard_sso_email_domain = var.dashboard_sso_email_domain
-  dashboard_sso_enabled      = var.dashboard_sso_enabled
-  dashboard_sso_policy_id    = var.dashboard_sso_policy_id
+  cloudflare_account_id                          = var.cloudflare_account_id
+  cloudflare_zero_trust_access_identity_provider = module.cloudflare_access.auth0_idp_oidc
+  cloudflare_zone_name                           = var.cloudflare_zone_name
+  dashboard_sso_email_domain                     = var.dashboard_sso_email_domain
+  dashboard_sso_enabled                          = var.dashboard_sso_enabled
+  dashboard_sso_policy_id                        = var.dashboard_sso_policy_id
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -80,6 +80,16 @@ variable "dashboard_sso_enabled" {
   default     = false
 }
 
+variable "dashboard_sso_app_id" {
+  description = "ID of the connector-generated dash_sso Access application, imported and managed here."
+  type        = string
+}
+
+variable "dashboard_sso_policy_id" {
+  description = "ID of the connector-generated allow-email-domain Access policy attached to the dash_sso application."
+  type        = string
+}
+
 variable "hcp_acs_url" {
   description = "SAML Assertion Consumer Service (ACS) url."
   type        = string


### PR DESCRIPTION
Imports the connector-generated `dash_sso` Access application into `module.cloudflare` and manages it:

- renames it `SSO App` -> `Cloudflare`
- attaches the cloudflare favicon (`logo_url`)
- pins the auto-generated `Allow email domain bendwyer.net` policy with `prevent_destroy` because deleting that policy locks admins out

Removes the manual `cloudflare_dashboard` bookmark — the SSO App tile does IdP-initiated login into the dashboard, so the bookmark is redundant.

`ignore_changes` keeps `app_launcher_visible` from being nulled (not settable on `dash_sso`, defaults `true`). `saas_app` will churn computed OIDC fields on every plan (provider bug #5731, no config-level fix); the SAML config is stable.